### PR TITLE
DBAAS-3258: Injection of libdontdie into haproxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+NAME = splicemachine/kubernetes-ingress
+VERSION = 2.0.11_0.0.1
+
+.PHONY: all build run ssh stop clean push realclean
+
+all: build
+
+build:
+	docker build -t $(NAME):$(VERSION) -f build/Dockerfile .
+
+push:
+	docker push $(NAME):$(VERSION)
+
+clean:
+	-docker rmi $(NAME):$(VERSION)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM golang:1.13.5-alpine AS libdontdie
+
+RUN apk --no-cache add git openssh gcc make automake build-base
+RUN mkdir -p /src
+RUN cd /src && \
+	git clone https://github.com/flonatel/libdontdie.git
+RUN cd /src/libdontdie/ && \
+	make
+
 FROM golang:1.13.5-alpine AS builder
 
 RUN apk --no-cache add git openssh
@@ -41,6 +50,7 @@ FROM haproxytech/haproxy-alpine:2.0.11
 
 RUN apk --no-cache add socat openssl util-linux openrc htop
 
+COPY --from=libdontdie /src/libdontdie/libdontdie.so /usr/lib/
 COPY /fs /
 COPY --from=builder /src/fs/haproxy-ingress-controller .
 

--- a/controller-tcp.go
+++ b/controller-tcp.go
@@ -28,6 +28,14 @@ func (c *HAProxyController) handleTCPServices() (needsReload bool, err error) {
 		if prt, errParse := strconv.ParseInt(portDest, 10, 64); errParse == nil {
 			portInt64 = prt
 		}
+
+		var sslCertificate string
+		var ssl bool
+		var alpn string
+		sslCertificate = HAProxyCertDir
+		ssl = true
+		alpn = "no-sslv3 no-tlsv10 no-tlsv11"
+
 		switch svc.Status {
 		case ADDED:
 			if err == nil {
@@ -43,14 +51,20 @@ func (c *HAProxyController) handleTCPServices() (needsReload bool, err error) {
 			err = c.frontendCreate(frontend)
 			LogErr(err)
 			err = c.frontendBindCreate(frontendName, models.Bind{
-				Address: "0.0.0.0:" + port,
-				Name:    "bind_1",
+				Address:        "0.0.0.0:" + port,
+				Name:           "bind_1",
+				Ssl:            ssl,
+				SslCertificate: sslCertificate,
+				Alpn:           alpn,
 			})
 			LogErr(err)
 			err = c.frontendBindCreate(frontendName, models.Bind{
-				Address: ":::" + port,
-				Name:    "bind_2",
-				V4v6:    true,
+				Address:        ":::" + port,
+				Name:           "bind_2",
+				V4v6:           true,
+				Ssl:            ssl,
+				SslCertificate: sslCertificate,
+				Alpn:           alpn,
 			})
 			LogErr(err)
 			ingress := &Ingress{

--- a/controller.go
+++ b/controller.go
@@ -343,7 +343,7 @@ func (c *HAProxyController) handleService(namespace *Namespace, ingress *Ingress
 	}
 
 	// No need to update BackendSwitching
-	if status == EMPTY && !activeSSLPassthrough {
+	if (status == EMPTY && !activeSSLPassthrough) || path.IsTCPService {
 		return backendName, newBackend, needReload, nil
 	}
 
@@ -365,8 +365,6 @@ func (c *HAProxyController) handleService(namespace *Namespace, ingress *Ingress
 			LogErr(err)
 		}
 		needReload = true
-	case path.IsTCPService:
-		// nothing to do
 	case path.IsSSLPassthrough:
 		c.addUseBackendRule(key, useBackendRule, FrontendSSL)
 		if activeSSLPassthrough {

--- a/fs/etc/init.d/haproxy
+++ b/fs/etc/init.d/haproxy
@@ -6,7 +6,7 @@ start)
       echo haproxy is running, pid=`cat /var/run/haproxy.pid`
       exit 1
    else
-      haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid
+      DD_TCP_KEEPALIVE_TIME=60 DD_TCP_KEEPALIVE_INTVL=5 DD_TCP_KEEPALIVE_PROBES=6 LD_PRELOAD=/usr/lib/libdontdie.so haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid
    fi   
    ;;
 stop)
@@ -29,7 +29,7 @@ status)
    ;;
 apply)   
    if [ -e /var/run/haproxy.pid ]; then
-      haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -sf $(cat /var/run/haproxy.pid)
+      DD_TCP_KEEPALIVE_TIME=60 DD_TCP_KEEPALIVE_INTVL=5 DD_TCP_KEEPALIVE_PROBES=6 LD_PRELOAD=/usr/lib/libdontdie.so haproxy -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid -sf $(cat /var/run/haproxy.pid)
    else
       $0 start
    fi


### PR DESCRIPTION
The `controller-tcp.go` code changes are a bit of a hack, since the base project does not yet support a ConfigMap or Annotation for SSL on TCP sessions.  I simply forced all TCP connection to terminate SSL using the default defined SSL certificates.  For our purpose this is fine.  I suspect eventually as we merge changes to the parent project into our version we will inherit code that handles SSL for TCP connections.

I've submitted the controller.go changes to the parent project and it was accepted into the dev branch.  This was a bug.

The injection for libdontdie was very easy since the launching of haproxy is simply done through init.d script.  